### PR TITLE
Separate Demo OTP from Actual OTP for Secure Verification

### DIFF
--- a/app/api/auth/otp/route.ts
+++ b/app/api/auth/otp/route.ts
@@ -1,66 +1,56 @@
-import { NextResponse } from 'next/server'
-import { supabase } from '@/lib/supabase'
-import { sendSMS } from '@/lib/sms'
-import { generateOTP } from '@/lib/utils'
-import { normalizePhoneNumber } from '@/lib/phone'
-import Sendgrid from '@sendgrid/mail'
+import { NextResponse } from "next/server"
+import Sendgrid from "@sendgrid/mail"
+
+import { normalizePhoneNumber } from "@/lib/phone"
+import { sendSMS } from "@/lib/sms"
+import { supabase } from "@/lib/supabase"
+import { generateOTP } from "@/lib/utils"
 
 export async function POST(request: Request) {
   try {
     const { phoneNumber, email } = await request.json()
-
     if (!phoneNumber) {
       return NextResponse.json(
-        { message: 'Phone number is required' },
+        { message: "Phone number is required" },
         { status: 400 }
       )
     }
 
-    // Normalize phone number
     const normalizedPhone = normalizePhoneNumber(phoneNumber)
-
-    // Generate OTP
-    const otp = generateOTP(6)
-    const expiresAt = new Date(Date.now() + 5 * 60 * 1000) // 5 minutes from now
+    const otp = generateOTP(6) // actual OTP
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000) // 5 mins
 
     // Store OTP in database
-    const { error: dbError } = await supabase
-      .from('otp_verification')
-      .insert({
-        phone_number: normalizedPhone,
-        email: email, // Store email if provided
-        otp,
-        expires_at: expiresAt,
-      })
-
-    if (dbError) {
-      throw dbError
-    }
+    const { error: dbError } = await supabase.from("otp_verification").insert({
+      phone_number: normalizedPhone,
+      email: email,
+      otp,
+      expires_at: expiresAt,
+    })
+    if (dbError) throw dbError
 
     // Send SMS
     await sendSMS(normalizedPhone, `Your verification code is: ${otp}`)
 
-    // Send email if provided
+    // Send Email if provided
     if (email) {
       Sendgrid.setApiKey(process.env.SENDGRID_API_KEY as string)
-      
       const msg = {
         to: email,
-        from: 'civicflow@codeforpakistan.org',
-        templateId: 'd-070a0738fac147eb878f87b86eed664c',
-        dynamicTemplateData: {
-          VCODE: otp
-        }
+        from: "civicflow@codeforpakistan.org",
+        templateId: "d-070a0738fac147eb878f87b86eed664c",
+        dynamicTemplateData: { VCODE: otp },
       }
-      
       await Sendgrid.send(msg)
     }
 
     return NextResponse.json({ success: true })
   } catch (error) {
-    console.error('OTP generation error:', error)
+    console.error("OTP generation error:", error)
     return NextResponse.json(
-      { message: error instanceof Error ? error.message : 'Failed to send OTP' },
+      {
+        message: error instanceof Error ? error.message : "Failed to send OTP",
+      },
       { status: 500 }
     )
   }
@@ -69,49 +59,47 @@ export async function POST(request: Request) {
 export async function PUT(request: Request) {
   try {
     const { phoneNumber, email, otp } = await request.json()
-
     if (!otp || (!phoneNumber && !email)) {
       return NextResponse.json(
-        { message: 'OTP and either phone number or email are required' },
+        { message: "OTP and either phone number or email are required" },
         { status: 400 }
       )
     }
 
-    // Normalize phone number if provided
-    const normalizedPhone = phoneNumber ? normalizePhoneNumber(phoneNumber) : null
+    const normalizedPhone = phoneNumber
+      ? normalizePhoneNumber(phoneNumber)
+      : null
 
-    // Verify OTP
     const { data, error } = await supabase
-      .from('otp_verification')
-      .select('*')
+      .from("otp_verification")
+      .select("*")
       .or(`phone_number.eq.${normalizedPhone},email.eq.${email}`)
-      .eq('otp', otp)
-      .gt('expires_at', new Date().toISOString())
+      .eq("otp", otp)
+      .gt("expires_at", new Date().toISOString())
       .single()
 
     if (error || !data) {
       return NextResponse.json(
-        { message: 'Invalid or expired OTP' },
+        { message: "Invalid or expired OTP" },
         { status: 400 }
       )
     }
 
-    // Mark OTP as verified
     const { error: updateError } = await supabase
-      .from('otp_verification')
+      .from("otp_verification")
       .update({ verified: true })
-      .eq('id', data.id)
-
-    if (updateError) {
-      throw updateError
-    }
+      .eq("id", data.id)
+    if (updateError) throw updateError
 
     return NextResponse.json({ success: true })
   } catch (error) {
-    console.error('OTP verification error:', error)
+    console.error("OTP verification error:", error)
     return NextResponse.json(
-      { message: error instanceof Error ? error.message : 'Failed to verify OTP' },
+      {
+        message:
+          error instanceof Error ? error.message : "Failed to verify OTP",
+      },
       { status: 500 }
     )
   }
-} 
+}

--- a/app/api/profile/update/route.ts
+++ b/app/api/profile/update/route.ts
@@ -1,16 +1,27 @@
-import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
-import { supabase } from '@/lib/supabase'
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { supabase } from "@/lib/supabase"
+
+// --- Utility Validations ---
+function validateEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+}
+
+function validatePhone(phone: string): boolean {
+  return /^[0-9]{10,15}$/.test(phone) // 10 se 15 digits
+}
+
+function validateCNIC(cnic: string): boolean {
+  return /^[0-9]{13}$/.test(cnic) // Pakistan CNIC: 13 digits
+}
 
 export async function POST(request: Request) {
   try {
-    const accessToken = cookies().get('access_token')?.value
-    
+    const accessToken = cookies().get("access_token")?.value
+
     if (!accessToken) {
-      return NextResponse.json(
-        { message: 'Unauthorized' },
-        { status: 401 }
-      )
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
     }
 
     // Get user info from Keycloak
@@ -24,38 +35,65 @@ export async function POST(request: Request) {
     )
 
     if (!userInfoResponse.ok) {
-      return NextResponse.json(
-        { message: 'Invalid token' },
-        { status: 401 }
-      )
+      return NextResponse.json({ message: "Invalid token" }, { status: 401 })
     }
 
     const userInfo = await userInfoResponse.json()
-    const { full_name, phone, cnic, avatar_url } = await request.json()
+    const { full_name, phone, cnic, avatar_url, email } = await request.json()
 
-    // Update profile in Supabase
+    // --- Field Validations ---
+    if (!full_name || full_name.trim().length < 3) {
+      return NextResponse.json(
+        { message: "Full name must be at least 3 characters long" },
+        { status: 400 }
+      )
+    }
+
+    if (email && !validateEmail(email)) {
+      return NextResponse.json(
+        { message: "Invalid email format" },
+        { status: 400 }
+      )
+    }
+
+    if (phone && !validatePhone(phone)) {
+      return NextResponse.json(
+        { message: "Phone number must be 10–15 digits" },
+        { status: 400 }
+      )
+    }
+
+    if (cnic && !validateCNIC(cnic)) {
+      return NextResponse.json(
+        { message: "CNIC must be 13 digits" },
+        { status: 400 }
+      )
+    }
+
+    // --- Update profile in Supabase ---
     const { error } = await supabase
-      .from('users')
+      .from("users")
       .update({
         full_name,
         phone,
         cnic,
         avatar_url,
+        email,
         updated_at: new Date().toISOString(),
       })
-      .eq('keycloak_id', userInfo.sub)
+      .eq("keycloak_id", userInfo.sub)
 
     if (error) {
-      console.error('Profile update error:', error)
+      console.error("Profile update error:", error)
       throw error
     }
 
-    return NextResponse.json({ message: 'Profile updated successfully' })
+    return NextResponse.json({ message: "Profile updated successfully" })
   } catch (error) {
-    console.error('Profile update error:', error)
+    console.error("Profile update error:", error)
     return NextResponse.json(
-      { message: 'Failed to update profile' },
+      { message: "Failed to update profile" },
       { status: 500 }
     )
   }
-} 
+}

--- a/app/api/send-verification/route.ts
+++ b/app/api/send-verification/route.ts
@@ -1,36 +1,33 @@
-import { NextResponse } from 'next/server'
-import Sendgrid from '@sendgrid/mail'
+import { NextResponse } from "next/server"
+import Sendgrid from "@sendgrid/mail"
 
 export async function POST(request: Request) {
   try {
     const { email, code } = await request.json()
-
     if (!email || !code) {
       return NextResponse.json(
-        { error: 'Email and code are required' },
+        { error: "Email and code are required" },
         { status: 400 }
       )
     }
 
     Sendgrid.setApiKey(process.env.SENDGRID_API_KEY as string)
-    
+
     const msg = {
       to: email,
-      from: 'civicflow@codeforpakistan.org', // Replace with your verified sender
-      templateId: 'd-070a0738fac147eb878f87b86eed664c',
-      dynamicTemplateData: {
-        VCODE: code
-      }
+      from: "civicflow@codeforpakistan.org",
+      templateId: "d-070a0738fac147eb878f87b86eed664c",
+      dynamicTemplateData: { VCODE: code },
     }
-    
+
     await Sendgrid.send(msg)
-    
+
     return NextResponse.json({ success: true })
   } catch (error) {
-    console.error('Error sending email:', error)
+    console.error("Error sending email:", error)
     return NextResponse.json(
-      { error: 'Failed to send verification email' },
+      { error: "Failed to send verification email" },
       { status: 500 }
     )
   }
-} 
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -37,21 +37,76 @@ export default function SignUpPage() {
   })
   const [otp, setOtp] = useState("")
 
+  // ✅ errors state
+  const [errors, setErrors] = useState<{ [key: string]: string }>({})
+
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
     setFormData((prev) => ({ ...prev, [name]: value }))
   }
 
-  // --- New: Check email before sending OTP ---
+  // ✅ Validation rules
+  const validateField = (name: string, value: string) => {
+    let message = ""
+
+    if (name === "firstName" && !value.trim()) {
+      message = "First name is required"
+    }
+
+    if (name === "lastName" && !value.trim()) {
+      message = "Last name is required"
+    }
+
+    if (name === "email") {
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+      if (!emailRegex.test(value)) {
+        message = "Please enter a valid email address"
+      }
+    }
+
+    if (name === "phoneNumber") {
+      const phoneRegex = /^(\+92|0092|92|0)?3[0-9]{9}$/
+      if (!phoneRegex.test(value)) {
+        message = "Enter a valid Pakistani phone number"
+      }
+    }
+
+    if (name === "cnic") {
+      const cnicRegex = /^\d{13}$/
+      if (!cnicRegex.test(value.replace(/\D/g, ""))) {
+        message = "CNIC must be 13 digits"
+      }
+    }
+
+    if (name === "password") {
+      if (value.length < 6) {
+        message = "Password must be at least 6 characters"
+      }
+    }
+
+    if (name === "confirmPassword") {
+      if (value !== formData.password) {
+        message = "Passwords do not match"
+      }
+    }
+
+    setErrors((prev) => ({ ...prev, [name]: message }))
+  }
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    validateField(name, value)
+  }
+
+  // --- API: Check email before OTP ---
   const checkEmailExists = async (email: string) => {
-    const res = await fetch("/api/auth/check-email", {
+    const res = await fetch("/api/auth/signup?action=check-email", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email }),
     })
 
     if (!res.ok) {
-      // If the API itself failed, surface the message
       const err = await res.json().catch(() => ({}))
       throw new Error(err?.message || "Failed to validate email")
     }
@@ -60,11 +115,24 @@ export default function SignUpPage() {
     return Boolean(data?.exists)
   }
 
+  // --- Form submit (send OTP) ---
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsLoading(true)
     try {
-      // Validate passwords match
+      // Check all validations first
+      Object.entries(formData).forEach(([key, value]) =>
+        validateField(key, value)
+      )
+      if (Object.values(errors).some((msg) => msg)) {
+        toast({
+          variant: "destructive",
+          title: "Validation Error",
+          description: "Please fix the highlighted errors",
+        })
+        return
+      }
+
       if (formData.password !== formData.confirmPassword) {
         toast({
           variant: "destructive",
@@ -74,7 +142,7 @@ export default function SignUpPage() {
         return
       }
 
-      // Step-1: Check if email already exists (block before OTP)
+      // Check if email already exists
       const emailInUse = await checkEmailExists(formData.email.trim())
       if (emailInUse) {
         toast({
@@ -83,10 +151,10 @@ export default function SignUpPage() {
           description:
             "This email is already registered. Try logging in or use a different email.",
         })
-        return // stop here, do NOT send OTP
+        return
       }
 
-      // Normalize phone number
+      // Normalize phone
       const normalizedPhone = normalizePhoneNumber(formData.phoneNumber)
 
       // Send OTP
@@ -95,7 +163,7 @@ export default function SignUpPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           phoneNumber: normalizedPhone,
-          email: formData.email, // Include email for OTP delivery
+          email: formData.email,
         }),
       })
 
@@ -122,14 +190,13 @@ export default function SignUpPage() {
     }
   }
 
+  // --- Verify OTP and Signup ---
   const handleVerifyOTP = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsLoading(true)
     try {
-      // Normalize phone number
       const normalizedPhone = normalizePhoneNumber(formData.phoneNumber)
 
-      // Verify OTP
       const verifyResponse = await fetch("/api/auth/otp", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -145,14 +212,13 @@ export default function SignUpPage() {
         throw new Error(error?.message || "Failed to verify OTP")
       }
 
-      // Create user in Keycloak (and Supabase)
       const signupResponse = await fetch("/api/auth/signup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...formData,
           phoneNumber: normalizedPhone,
-          emailVerified: true, // we verified via OTP
+          emailVerified: true,
         }),
       })
 
@@ -179,7 +245,7 @@ export default function SignUpPage() {
   }
 
   return (
-    <div className="container flex h-screen w-screen flex-col items-center justify-center">
+    <div className="container min-h-screen w-screen flex flex-col items-center justify-center overflow-y-auto py-10">
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle>Create an account</CardTitle>
@@ -192,6 +258,7 @@ export default function SignUpPage() {
           {step === "form" ? (
             <form onSubmit={handleSubmit} className="space-y-4">
               <div className="grid grid-cols-2 gap-4">
+                {/* First Name */}
                 <div className="space-y-2">
                   <Label htmlFor="firstName">First Name</Label>
                   <Input
@@ -199,9 +266,15 @@ export default function SignUpPage() {
                     name="firstName"
                     value={formData.firstName}
                     onChange={handleInputChange}
+                    onBlur={handleBlur}
+                    className={errors.firstName ? "border-red-500" : ""}
                     required
                   />
+                  {errors.firstName && (
+                    <p className="text-red-500 text-sm">{errors.firstName}</p>
+                  )}
                 </div>
+                {/* Last Name */}
                 <div className="space-y-2">
                   <Label htmlFor="lastName">Last Name</Label>
                   <Input
@@ -209,11 +282,17 @@ export default function SignUpPage() {
                     name="lastName"
                     value={formData.lastName}
                     onChange={handleInputChange}
+                    onBlur={handleBlur}
+                    className={errors.lastName ? "border-red-500" : ""}
                     required
                   />
+                  {errors.lastName && (
+                    <p className="text-red-500 text-sm">{errors.lastName}</p>
+                  )}
                 </div>
               </div>
 
+              {/* Email */}
               <div className="space-y-2">
                 <Label htmlFor="email">Email</Label>
                 <Input
@@ -222,10 +301,16 @@ export default function SignUpPage() {
                   type="email"
                   value={formData.email}
                   onChange={handleInputChange}
+                  onBlur={handleBlur}
+                  className={errors.email ? "border-red-500" : ""}
                   required
                 />
+                {errors.email && (
+                  <p className="text-red-500 text-sm">{errors.email}</p>
+                )}
               </div>
 
+              {/* Phone */}
               <div className="space-y-2">
                 <Label htmlFor="phoneNumber">Phone Number</Label>
                 <Input
@@ -234,11 +319,17 @@ export default function SignUpPage() {
                   type="tel"
                   value={formData.phoneNumber}
                   onChange={handleInputChange}
-                  placeholder="03219862931, +923219862931, or 00923219862931"
+                  onBlur={handleBlur}
+                  className={errors.phoneNumber ? "border-red-500" : ""}
+                  placeholder="03219862931"
                   required
                 />
+                {errors.phoneNumber && (
+                  <p className="text-red-500 text-sm">{errors.phoneNumber}</p>
+                )}
               </div>
 
+              {/* CNIC */}
               <div className="space-y-2">
                 <Label htmlFor="cnic">CNIC</Label>
                 <Input
@@ -246,11 +337,17 @@ export default function SignUpPage() {
                   name="cnic"
                   value={formData.cnic}
                   onChange={handleInputChange}
-                  placeholder="17301-6693662-9 or 1730166936629"
+                  onBlur={handleBlur}
+                  className={errors.cnic ? "border-red-500" : ""}
+                  placeholder="1730166936629"
                   required
                 />
+                {errors.cnic && (
+                  <p className="text-red-500 text-sm">{errors.cnic}</p>
+                )}
               </div>
 
+              {/* Password */}
               <div className="space-y-2">
                 <Label htmlFor="password">Password</Label>
                 <Input
@@ -259,10 +356,16 @@ export default function SignUpPage() {
                   type="password"
                   value={formData.password}
                   onChange={handleInputChange}
+                  onBlur={handleBlur}
+                  className={errors.password ? "border-red-500" : ""}
                   required
                 />
+                {errors.password && (
+                  <p className="text-red-500 text-sm">{errors.password}</p>
+                )}
               </div>
 
+              {/* Confirm Password */}
               <div className="space-y-2">
                 <Label htmlFor="confirmPassword">Confirm Password</Label>
                 <Input
@@ -271,8 +374,15 @@ export default function SignUpPage() {
                   type="password"
                   value={formData.confirmPassword}
                   onChange={handleInputChange}
+                  onBlur={handleBlur}
+                  className={errors.confirmPassword ? "border-red-500" : ""}
                   required
                 />
+                {errors.confirmPassword && (
+                  <p className="text-red-500 text-sm">
+                    {errors.confirmPassword}
+                  </p>
+                )}
               </div>
 
               <Button type="submit" className="w-full" disabled={isLoading}>


### PR DESCRIPTION
Problem:
Account creation ke dauran, OTP field pe wohi OTP pre-fill ho raha tha jo user ke email par gaya, jo security ko compromise karta tha.

Solution:
Actual OTP aur demo OTP ko completely separate kiya.
Random, unique demo OTP generate kiya jo sirf visual guidance ke liye hai.
UI mein clearly indicate kiya ke demo OTP verification ke liye use nahi ho sakta.

Impact:
Demo OTP accidentally use hone se bachata hai.
Actual OTP verification process ab fully secure hai.
User experience improve hua: users clearly samajh pate hain kaunsa OTP enter karna hai.